### PR TITLE
accept generic credential provider in S3Client

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ documentation = "http://dualspark.github.io/rusoto/rusoto/index.html"
 [dependencies]
 xml-rs = "=0.1.26"
 time = "=0.1.32"
-openssl = "=0.6.6"
+openssl = "=0.6.7"
 hyper = "=0.6.11"
 url = "=0.2.37"
 rustc-serialize = "=0.3.16"

--- a/src/s3.rs
+++ b/src/s3.rs
@@ -41,7 +41,7 @@ pub enum CannedAcl {
 }
 
 impl<'a> S3Helper<'a> {
-	pub fn new(credentials: DefaultAWSCredentialsProviderChain, region:&'a Region) -> S3Helper<'a> {
+	pub fn new<CP: AWSCredentialsProvider + 'a>(credentials: CP, region:&'a Region) -> S3Helper<'a> {
 		S3Helper { client: S3Client::new(credentials, region) }
 	}
 


### PR DESCRIPTION
This will allow developers to implement their own credential providers (like I did :)) and use them in the S3Client