### PR TITLE
Return errors instead of panicking

### DIFF
--- a/AWS-CREDENTIALS.md
+++ b/AWS-CREDENTIALS.md
@@ -3,17 +3,17 @@
 Rusoto will search for credentials in this order:
 
 1. Environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`.
-2. AWS Credentials file: `~/.aws/credentials`.  It will use `aws_access_key_id` and `aws_secret_access_key` fields.  
+2. AWS Credentials file: `~/.aws/credentials`.  It will use `aws_access_key_id` and `aws_secret_access_key` fields.
 Profiles are supported.
 3. IAM instance profile.  Rusoto will query the metadata service for an instance profile/role and fetch the access key, secret access key and token to supply those for requests.
 
-If Rusoto exhausts all three options it will panic.
+If Rusoto exhausts all three options it will return an error.
 
 #### Credential refreshing
 
 Credentials obtained from environment variables and credential files expire ten minutes after being acquired, and are refreshed on subsequent calls to `get_credentials()`.
 
-IAM instance profile credentials are refreshed as needed.  Upon calling `get_credentials()` it will see if they are expired or not.  If expired, it attempts to get new credentials from the metadata service.  If that fails it will panic.  IAM credentials expiration time comes from the IAM metadata response.
+IAM instance profile credentials are refreshed as needed.  Upon calling `get_credentials()` it will see if they are expired or not.  If expired, it attempts to get new credentials from the metadata service.  If that fails it will return an error.  IAM credentials expiration time comes from the IAM metadata response.
 
 #### Local integration testing of IAM credentials
 

--- a/codegen/s3.rs
+++ b/codegen/s3.rs
@@ -11708,7 +11708,7 @@ impl<'a> S3Client<'a> {
 						return Ok(CreateBucketOutput{location: header.value_string()});
 					}
 				}
-				panic!("Something went wrong when creating a bucket.");
+				Err(AWSError::new("Something went wrong when creating a bucket."))
 			}
 			_ => {
 				Err(AWSError::new("error in create_bucket"))

--- a/src/bin/main.rs
+++ b/src/bin/main.rs
@@ -18,7 +18,7 @@ fn main() {
 	let provider = DefaultAWSCredentialsProviderChain::new();
 	let region = Region::UsEast1;
 
-	let provider2 = ProfileCredentialsProvider::new();
+	let provider2 = ProfileCredentialsProvider::new().unwrap();
 
 	// Creates an SQS client with its own copy of the credential provider chain:
 	let mut sqs = SQSHelper::new(provider2, &region);

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -21,12 +21,8 @@ use hyper::header::Connection;
 use error::*;
 use regex::Regex;
 
-extern crate rustc_serialize;
-use self::rustc_serialize::json::*;
-
-extern crate chrono;
-use self::chrono::*;
-
+use serialize::json::*;
+use chrono::*;
 
 /// Represents AWS credentials.  Includes access key, secret key, token (for IAM profiles) and expiration timestamp.
 #[derive(Clone, Debug)]
@@ -327,11 +323,7 @@ impl AWSCredentialsProvider for IAMRoleCredentialsProvider {
                 Some(val) => expiration = val.to_string().replace("\"", "")
             };
 
-            let expiration_time;
-            match expiration.parse::<DateTime<UTC>>() {
-                Err(why) => panic!("Kabloey on parse: {}", why),
-                Ok(val) => expiration_time = val
-            };
+            let expiration_time = try!(expiration.parse());
 
             let token_from_response;
             match json_object.find("Token") {

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -455,7 +455,7 @@ mod tests {
 
      #[test]
      fn profile_credentials_provider_profile_name() {
-        let mut provider = ProfileCredentialsProvider::new();
+        let mut provider = ProfileCredentialsProvider::new().unwrap();
         assert_eq!("default", provider.get_profile());
         assert_eq!("foo", provider.with_profile("foo").get_profile());
      }

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -12,7 +12,6 @@ use std::env;
 use std::fs;
 use std::fs::File;
 use std::path::Path;
-use std::error::Error;
 use std::io::prelude::*;
 use std::io::BufReader;
 use std::ascii::AsciiExt;
@@ -178,7 +177,6 @@ impl ProfileCredentialsProvider {
 
 fn parse_credentials_file(file_with_path: &str) -> Result<HashMap<String, AWSCredentials>, AWSError> {
     let path = Path::new(&file_with_path);
-    let display = path.display();
 
     match fs::metadata(&path) {
         Err(_) => return Err(AWSError::new("Couldn't stat credentials file.")),
@@ -189,10 +187,7 @@ fn parse_credentials_file(file_with_path: &str) -> Result<HashMap<String, AWSCre
         }
     };
 
-    let file = match File::open(&path) {
-        Err(why) => panic!("couldn't open {}: {}", display, Error::description(&why)),
-        Ok(opened_file) => opened_file,
-    };
+    let file = try!(File::open(&path));
 
     let profile_regex = Regex::new(r"^\[([^\]]+)\]$").unwrap();
     let mut profiles: HashMap<String, AWSCredentials> = HashMap::new();

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,7 @@
 //!
 
 use std::fmt;
+use std::io::Error as IoError;
 use xmlutil::XmlParseError;
 
 /// Simple wrapper around a String to store the error
@@ -14,6 +15,12 @@ impl AWSError {
 	pub fn new<S>(msg:S) -> AWSError where S:Into<String>{
 		AWSError(msg.into())
 	}
+}
+
+impl From<IoError> for AWSError {
+    fn from(err: IoError) -> AWSError {
+        AWSError(format!("{}", err))
+    }
 }
 
 impl From<XmlParseError> for AWSError {

--- a/src/error.rs
+++ b/src/error.rs
@@ -27,3 +27,5 @@ impl fmt::Display for AWSError {
         write!(f, "{}", self)
     }
 }
+
+pub type AWSResult<T> = Result<T, AWSError>;

--- a/src/error.rs
+++ b/src/error.rs
@@ -5,6 +5,9 @@
 
 use std::fmt;
 use std::io::Error as IoError;
+
+use chrono::format::ParseError as ChronoParseError;
+
 use xmlutil::XmlParseError;
 
 /// Simple wrapper around a String to store the error
@@ -15,6 +18,12 @@ impl AWSError {
 	pub fn new<S>(msg:S) -> AWSError where S:Into<String>{
 		AWSError(msg.into())
 	}
+}
+
+impl From<ChronoParseError> for AWSError {
+    fn from(err: ChronoParseError) -> AWSError {
+        AWSError(format!("{}", err))
+    }
 }
 
 impl From<IoError> for AWSError {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ extern crate url;
 extern crate rustc_serialize as serialize;
 extern crate regex;
 extern crate crypto;
+extern crate chrono;
 
 #[macro_use] pub mod params;
 #[macro_use] pub mod signature;


### PR DESCRIPTION
There are a few places where rusoto will panic instead of returning an error to the calling code. I went through and converted these panics into errors so library authors can handle these cases as they please. I also added a type alias for results: `AWSResult<T> = Result<T, AWSError>` that will probably come in handy.