### PR TITLE
Upgrade to hyper 0.7.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ exclude = [".gitignore", ".travis.yml", "docgen.sh", "codegen/*.py", "codegen/re
 [dependencies]
 xml-rs = "^0.1.26"
 time = "^0.1.32"
-openssl = "^0.6.7"
-hyper = "^0.6.15"
+openssl = "^0.7.1"
+hyper = "^0.7.0"
 url = "^0.2.37"
 rustc-serialize = "^0.3.16"
 regex = "^0.1.41"


### PR DESCRIPTION
impossible to compile hyper 0.6 version with modern libs:
```
$ cargo build
native library `openssl` is being linked to by more than one version
of the same package, but it can only be linked once; try updating
or pinning your dependencies to ensure that this package only shows
up once

  openssl-sys v0.7.1
  openssl-sys v0.6.7
```

This PR updates dependencies. Also I've tested it.