### PR TITLE
Run beta and nightly in travis, allowing errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,11 @@
 language: rust
 rust:
   - stable
+  - beta
+  - nightly
 notifications:
   email: false
+matrix:
+  allow_failures:
+    - rust: beta
+    - rust: nightly


### PR DESCRIPTION
Brought up in #133 

Runs the test suite against rust beta and nightly, but doesn't fail the whole build if they error.